### PR TITLE
"JobDefinitionName" property in JobDefinition class is not required

### DIFF
--- a/troposphere/batch.py
+++ b/troposphere/batch.py
@@ -94,7 +94,7 @@ class JobDefinition(AWSObject):
         "Type": (basestring, True),
         "Parameters": (dict, True),
         "ContainerProperties": (ContainerProperties, False),
-        "JobDefinitionName": (basestring, True),
+        "JobDefinitionName": (basestring, False),
         "RetryStrategy": (RetryStrategy, False)
     }
 


### PR DESCRIPTION
According to cloudformation document https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-jobdefinition.html#cfn-batch-jobdefinition-jobdefinitionname